### PR TITLE
Follow-up: Neutral rating label, chip overflow + About card fixes

### DIFF
--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -52,7 +52,7 @@ export const POSTS = [
 export const RATINGS = {
   highly:      { label: 'Highly recommend',        glyph: '●●●●', color: '#2a6e9a', bg: 'rgba(42,110,154,0.12)',  dark: '#1e5070' },
   recommend:   { label: 'Recommend',               glyph: '●●●○', color: '#1f7a6b', bg: 'rgba(31,122,107,0.12)',  dark: '#155248' },
-  situational: { label: 'Recommend situationally', glyph: '●●○○', color: '#c08a2c', bg: 'rgba(192,138,44,0.14)',  dark: '#7e5a18' },
+  situational: { label: 'Neutral',                 glyph: '●●○○', color: '#c08a2c', bg: 'rgba(192,138,44,0.14)',  dark: '#7e5a18' },
   not:         { label: 'Do not recommend',        glyph: '●○○○', color: '#9a3a3a', bg: 'rgba(154,58,58,0.10)',   dark: '#7a2d2d' },
 };
 

--- a/src/pages/About.module.css
+++ b/src/pages/About.module.css
@@ -30,6 +30,7 @@
 .body {
   display: grid;
   grid-template-columns: 1fr;
+  align-items: start;
   gap: 24px;
   padding: 24px 20px 48px;
 }

--- a/src/pages/Writing.js
+++ b/src/pages/Writing.js
@@ -118,7 +118,7 @@ export default function Writing() {
           />
           <FilterPill
             label="Rating" value={rating} onChange={setRating} accent={tint.accent} fg={fg} bg={bg}
-            options={[['all','Any'],['highly','●●●● Highly'],['recommend','●●●○ Recommend'],['situational','●●○○ Sometimes'],['not','●○○○ Skip']]}
+            options={[['all','Any'],['highly','●●●● Highly'],['recommend','●●●○ Recommend'],['situational','●●○○ Neutral'],['not','●○○○ Skip']]}
           />
           <FilterPill
             label="Tag" value={tag} onChange={setTag} accent={tint.accent} fg={fg} bg={bg}


### PR DESCRIPTION
Follow-up tweaks after the responsive refactor (#24). The first two commits were pushed to the refactor branch *after* #24 merged, so they weren't included — carried over here.

## Changes
- **Rating chip overflow** — shorten the `situational` tier label from "Recommend situationally" to **"Neutral"** so the chip fits the narrow recent-writing columns on Home (it was overflowing).
- **About card stretching** — add `align-items: start` to the About body grid so the info cards hug their natural height and float at the top instead of being stretched to match the taller bio column.
- **Filter consistency** — rename the Writing page's Rating filter option "Sometimes" → **"Neutral"** to match the chip label.

## Verification
- Confirmed in-browser: recent-writing chip now reads `●●○○ NEUTRAL` and fits; About cards column hugs content (525px) instead of stretching to the bio's 619px at 1024px.
- Test suite: 5/5 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)