### PR TITLE
Add SPA fallback for GitHub Pages deep links

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preston McDonald</title>
+    <!--
+      Single Page Apps for GitHub Pages
+      MIT License - https://github.com/rafgraph/spa-github-pages
+
+      GitHub Pages has no server-side routing, so any unknown path (a deep link
+      or a refresh on a client route like /about) is served this 404 page.
+      This script rewrites the path into a query string and redirects to the
+      site root; index.html then decodes it back and React Router takes over.
+
+      pathSegmentsToKeep = 0 because this is a root user/org page
+      (https://prmcdonald.github.io), not a project page under a subpath.
+    -->
+    <script type="text/javascript">
+      var pathSegmentsToKeep = 0;
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          '//' +
+          l.hostname +
+          (l.port ? ':' + l.port : '') +
+          l.pathname
+            .split('/')
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join('/') +
+          '/?/' +
+          l.pathname
+            .slice(1)
+            .split('/')
+            .slice(pathSegmentsToKeep)
+            .join('/')
+            .replace(/&/g, '~and~') +
+          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,26 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Preston McDonald</title>
+    <!--
+      Single Page Apps for GitHub Pages
+      MIT License - https://github.com/rafgraph/spa-github-pages
+      Decodes the redirect that 404.html performs, so deep links / refreshes on
+      client-side routes (e.g. /about) resolve to the right route instead of 404.
+    -->
+    <script type="text/javascript">
+      (function (l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search
+            .slice(1)
+            .split('&')
+            .map(function (s) {
+              return s.replace(/~and~/g, '&');
+            })
+            .join('?');
+          window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      })(window.location);
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Problem
The app uses `BrowserRouter`, but GitHub Pages has no server-side routing. Loading a client route directly or refreshing on it (e.g. `https://prmcdonald.github.io/about`) returns a 404 instead of the app.

## Fix
The standard [rafgraph/spa-github-pages](https://github.com/rafgraph/spa-github-pages) technique:
- **`public/404.html`** — Pages serves this for any unknown path. It encodes the requested path into a query string and redirects to the site root. `pathSegmentsToKeep = 0` because this is a root user page (`prmcdonald.github.io`), not a project subpath.
- **`public/index.html`** — a small inline script decodes that query string back into the real path via `history.replaceState` before the app mounts, so React Router resolves the intended route.

## Verification
`npm run build` succeeds; confirmed `build/404.html` is emitted and the decode script is present in `build/index.html` (the explanatory HTML comment is stripped by CRA's minifier, but the functional script — `~and~`, `replaceState` — survives).

## Note
This is independent of the separate Pages **source** fix (switching Settings → Pages → Source to "GitHub Actions"), which is still required for the root URL to serve at all. This PR makes deep links work once the site is being served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)