### PR TITLE
Fix rating chip contrast in dark mode (WCAG AA)

### DIFF
--- a/src/components/RatingChip.js
+++ b/src/components/RatingChip.js
@@ -1,6 +1,6 @@
 import { RATINGS, fontMono } from '../data/posts';
 
-export default function RatingChip({ kind, size = 'sm' }) {
+export default function RatingChip({ kind, size = 'sm', dark = false }) {
   if (!kind) return null;
   const r = RATINGS[kind];
   const padY = size === 'sm' ? 3 : 5;
@@ -9,7 +9,7 @@ export default function RatingChip({ kind, size = 'sm' }) {
   return (
     <span style={{
       display: 'inline-flex', alignItems: 'center', gap: 6,
-      background: r.bg, color: r.dark,
+      background: dark ? r.darkBg : r.lightBg, color: dark ? r.darkText : r.lightText,
       padding: `${padY}px ${padX}px`, borderRadius: 4,
       fontFamily: fontMono, fontSize: fs, letterSpacing: 1, textTransform: 'uppercase',
       whiteSpace: 'nowrap',

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -49,11 +49,13 @@ export const POSTS = [
     tags: ['craft', 'writing'], rating: null, read: 5 },
 ];
 
+// Each rating carries WCAG-AA contrast pairs for both themes (text ≥ 4.5:1 on its
+// chip background). Light text is used on the dark/night theme, dark text on light.
 export const RATINGS = {
-  highly:      { label: 'Highly recommend',        glyph: '●●●●', color: '#2a6e9a', bg: 'rgba(42,110,154,0.12)',  dark: '#1e5070' },
-  recommend:   { label: 'Recommend',               glyph: '●●●○', color: '#1f7a6b', bg: 'rgba(31,122,107,0.12)',  dark: '#155248' },
-  situational: { label: 'Neutral',                 glyph: '●●○○', color: '#c08a2c', bg: 'rgba(192,138,44,0.14)',  dark: '#7e5a18' },
-  not:         { label: 'Do not recommend',        glyph: '●○○○', color: '#9a3a3a', bg: 'rgba(154,58,58,0.10)',   dark: '#7a2d2d' },
+  highly:      { label: 'Highly recommend', glyph: '●●●●', lightText: '#1e5070', lightBg: 'rgba(42,110,154,0.12)', darkText: '#8ecbf0', darkBg: 'rgba(86,160,205,0.22)' },
+  recommend:   { label: 'Recommend',        glyph: '●●●○', lightText: '#155248', lightBg: 'rgba(31,122,107,0.12)', darkText: '#74d6c0', darkBg: 'rgba(45,170,150,0.22)' },
+  situational: { label: 'Neutral',          glyph: '●●○○', lightText: '#7e5a18', lightBg: 'rgba(192,138,44,0.14)', darkText: '#e6c172', darkBg: 'rgba(200,150,60,0.22)' },
+  not:         { label: 'Do not recommend', glyph: '●○○○', lightText: '#7a2d2d', lightBg: 'rgba(154,58,58,0.10)',  darkText: '#f0a3a3', darkBg: 'rgba(190,90,90,0.22)' },
 };
 
 export const NOW_ITEMS = [

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -108,7 +108,7 @@ export default function Home() {
                 </MonoLabel>
                 <div className={styles.cardTitle}>{p.title}</div>
                 <div className={styles.cardBlurb}>{p.blurb}</div>
-                {p.rating && <div className={styles.cardRating}><RatingChip kind={p.rating} /></div>}
+                {p.rating && <div className={styles.cardRating}><RatingChip kind={p.rating} dark={isNight} /></div>}
               </Link>
             ))}
           </div>

--- a/src/pages/Post.js
+++ b/src/pages/Post.js
@@ -77,7 +77,7 @@ export default function Post() {
 
           {post.rating && (
             <div className={styles.ratingWrap}>
-              <RatingChip kind={post.rating} size="lg" />
+              <RatingChip kind={post.rating} size="lg" dark={isNight} />
             </div>
           )}
 

--- a/src/pages/Writing.js
+++ b/src/pages/Writing.js
@@ -9,7 +9,7 @@ import { usePageTheme } from '../hooks/usePageTheme';
 import { POSTS, fmtDate } from '../data/posts';
 import styles from './Writing.module.css';
 
-function PostRow({ p, last }) {
+function PostRow({ p, last, dark }) {
   return (
     <Link to={`/writing/${p.id}`} className={`${styles.row} ${last ? styles.rowLast : ''}`}>
       <time className={styles.rowDate}>{fmtDate(p.date)}</time>
@@ -35,12 +35,12 @@ function PostRow({ p, last }) {
         </div>
 
         {/* Mobile rating */}
-        {p.rating && <div className={styles.ratingMobile}><RatingChip kind={p.rating} /></div>}
+        {p.rating && <div className={styles.ratingMobile}><RatingChip kind={p.rating} dark={dark} /></div>}
       </div>
 
       {/* Desktop aside: rating + read time */}
       <div className={styles.aside}>
-        {p.rating && <RatingChip kind={p.rating} />}
+        {p.rating && <RatingChip kind={p.rating} dark={dark} />}
         <div className={styles.readMin}>{p.read} min</div>
       </div>
     </Link>
@@ -138,7 +138,7 @@ export default function Writing() {
               <div className={styles.yearLabel}>{y}</div>
               <div>
                 {byYear[y].map((p, i) => (
-                  <PostRow key={p.id} p={p} last={i === byYear[y].length - 1} />
+                  <PostRow key={p.id} p={p} last={i === byYear[y].length - 1} dark={isNight} />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## Problem
The rating chips (Highly recommend / Recommend / Neutral / Do not recommend) used a single dark text color in both themes. On the night theme that put dark text on a dark background — measured **1.77–2.32:1**, failing WCAG AA (needs ≥ 4.5:1 for this small text).

## Fix
Give each rating explicit **light/dark text + background pairs** in `RATINGS`, and have `RatingChip` pick the pair via a `dark` prop. `Home`, `Writing`, and `Post` pass `dark={isNight}`.

## Measured contrast (need ≥ 4.5:1)
| Rating | Dark mode before | Dark mode after | Light mode |
|---|---|---|---|
| Highly recommend | 1.87 ❌ | **7.11** ✅ | 6.83 ✅ |
| Recommend | 1.77 ❌ | **7.28** ✅ | 7.14 ✅ |
| Neutral | 2.32 ❌ | **7.09** ✅ | 5.10 ✅ |
| Do not recommend | 1.78 ❌ | **6.89** ✅ | 7.46 ✅ |

Light theme colors are unchanged (already passing).

## Verification
- Contrast computed with the WCAG relative-luminance formula against each chip's blended background.
- Verified legible in-browser on the dark theme (Writing/Post/Home).
- Test suite passes (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)